### PR TITLE
Feat add category to posts sanity

### DIFF
--- a/front/app/server/env.ts
+++ b/front/app/server/env.ts
@@ -1,8 +1,8 @@
 import "dotenv";
 
-const sanityId = process.env.REACT_APP_SANITY_PROJECT_ID;
-const sanityDataset = process.env.REACT_APP_SANITY_DATASET;
-const sanityToken = process.env.REACT_APP_SANITY_TOKEN;
+const sanityId = process.env.SANITY_PROJECT_ID;
+const sanityDataset = process.env.SANITY_DATASET;
+const sanityToken = process.env.SANITY_TOKEN;
 const gmailUser = process.env.GMAIL_USER;
 const gmailPassword = process.env.GMAIL_PASSWORD;
 const emailFrom = process.env.EMAIL_FROM;

--- a/sanity/schemaTypes/postsType.ts
+++ b/sanity/schemaTypes/postsType.ts
@@ -1,5 +1,14 @@
 import {defineField, defineType} from 'sanity'
 
+export const category = [
+  {title: 'Adoption', value: 'Adoption'},
+  {title: 'Education', value: 'Education'},
+  {title: 'Le Refuge', value: 'Le Refuge'},
+  {title: 'Sensibilisation', value: 'Sensibilisation'},
+  {title: 'Événements', value: 'Événements'},
+  {title: 'Vie sociale', value: 'Vie sociale'},
+]
+
 export const postsType = defineType({
   name: 'posts',
   title: 'Posts',
@@ -8,6 +17,15 @@ export const postsType = defineType({
     defineField({
       name: 'title',
       type: 'string',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'category',
+      type: 'string',
+      options: {
+        list: category.map(({title, value}) => ({title, value})),
+        layout: 'dropdown',
+      },
       validation: (rule) => rule.required(),
     }),
     defineField({


### PR DESCRIPTION
This pull request introduces changes to streamline environment variable usage and enhance the schema definition for post categories in the Sanity CMS. The most important changes include updating environment variable names for consistency and adding a new `category` field to the `postsType` schema.

### Environment variable updates:
* [`front/app/server/env.ts`](diffhunk://#diff-4a85fd2f63522b4191c20a4d93998b1575d35c22f5cd548283ac0c9089ce7d07L3-R5): Updated environment variable names from `REACT_APP_SANITY_*` to `SANITY_*` for better alignment with naming conventions and improved clarity.

### Sanity schema enhancements:
* [`sanity/schemaTypes/postsType.ts`](diffhunk://#diff-f116b2d9abb9ec99c71734608e878e6ee1fb31ad8d85f25f7e26df1b130e386eR3-R11): Added a `category` array defining available post categories, such as "Adoption," "Education," and "Événements."
* [`sanity/schemaTypes/postsType.ts`](diffhunk://#diff-f116b2d9abb9ec99c71734608e878e6ee1fb31ad8d85f25f7e26df1b130e386eR22-R30): Introduced a new `category` field in the `postsType` schema, configured with a dropdown layout and validation rules to ensure selection from predefined categories.