### PR TITLE
feat: create triptique reusable component

### DIFF
--- a/front/app/app.css
+++ b/front/app/app.css
@@ -213,4 +213,5 @@
   background-image: url("/public/assets/graphic-assets/Vector-underline.png");
   background-size: 100% 100%;
   background-repeat: no-repeat;
+  padding: 0.5rem;
 }

--- a/front/app/components/Triptique.tsx
+++ b/front/app/components/Triptique.tsx
@@ -1,0 +1,52 @@
+import type { TriptiqueProps } from "../types/types";
+
+export default function Triptique({
+  title,
+  highlight,
+  cards,
+  backgroundColor = "bg-white-custom",
+  cardBackgroundColor = "bg-beige",
+  titleColor = "text-dark",
+  cardTitleSize,
+  cardTitleColor = "text-dark",
+  cardTextColor = "text-dark",
+}: TriptiqueProps) {
+  return (
+    <section className="p-4">
+      <div className={`w-full py-16 px-4 rounded-2xl ${backgroundColor}`}>
+        <div className="max-w-7xl mx-auto">
+          <div className="text-center mb-12">
+            <h1 className={`title2 ${titleColor}`}>
+              {title} <span className="svg_background">{highlight}</span>
+            </h1>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+            {cards.map((card, index) => (
+              <div
+                key={index}
+                className={`${cardBackgroundColor} p-4 h-80 flex flex-col justify-center items-center text-left rounded-lg`}
+              >
+                <h2 className={`${cardTitleSize} ${cardTitleColor} mb-2`}>
+                  {card.title}
+                </h2>
+
+                {card.subtitle && (
+                  <h3 className={`title4 ${cardTitleColor} mb-6`}>
+                    {card.subtitle}
+                  </h3>
+                )}
+
+                <div className="flex-1 flex items-center justify-center">
+                  <p className={`text-small ${cardTextColor} leading-relaxed`}>
+                    {card.description}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/front/app/routes/home.tsx
+++ b/front/app/routes/home.tsx
@@ -1,6 +1,7 @@
 import type { MetaArgs } from "react-router";
 import headerDog from "~/../public/assets/graphic-assets/header-dog.png";
 import Banner from "../components/Banner";
+import Triptique from "../components/Triptique";
 
 export function meta({}: MetaArgs) {
   return [
@@ -10,6 +11,27 @@ export function meta({}: MetaArgs) {
 }
 
 export default function Home() {
+  const triptiqueData: [
+    { title: string; description: string },
+    { title: string; description: string },
+    { title: string; description: string },
+  ] = [
+    {
+      title: "- 5,8%",
+      description:
+        "Les adoptions sont en baisse constante, avec une diminution de 5,8 % en 2024 par rapport à 2023.",
+    },
+    {
+      title: "+ 1,5%",
+      description: "Nombre d’animaux abandonnés par rapport à 2022.",
+    },
+    {
+      title: "= 1465",
+      description:
+        "En Gironde, la SPA de Bordeaux et du Sud-Ouest a accueilli 1 465 animaux abandonnés en 2022, un chiffre en constante augmentation.",
+    },
+  ];
+
   return (
     <main>
       <Banner
@@ -26,6 +48,17 @@ export default function Home() {
           src: headerDog,
           alt: "Chien adorable",
         }}
+      />
+      <Triptique
+        title="Quelques"
+        highlight="statistiques clés"
+        cards={triptiqueData}
+        backgroundColor="bg-beige"
+        cardBackgroundColor="bg-blue"
+        titleColor="text-dark"
+        cardTitleSize="title1"
+        cardTitleColor="text-white-custom"
+        cardTextColor="text-beige"
       />
     </main>
   );

--- a/front/app/types/types.ts
+++ b/front/app/types/types.ts
@@ -54,3 +54,22 @@ export type BannerProps = {
   };
   backgroundClass?: string;
 };
+
+export type TriptiqueCard = {
+  title: string;
+  subtitle?: string;
+  description: string;
+};
+
+export type TriptiqueProps = {
+  title: string;
+  highlight?: string;
+  cards: [TriptiqueCard, TriptiqueCard, TriptiqueCard];
+  backgroundColor?: string;
+  cardBackgroundColor?: string;
+  titleColor?: string;
+  textColor?: string;
+  cardTitleSize?: string;
+  cardTitleColor?: string;
+  cardTextColor?: string;
+};


### PR DESCRIPTION
This pull request introduces a new `Triptique` component to display key statistics and integrates it into the `Home` route. It also includes a minor styling enhancement in the global CSS file. Below are the most important changes grouped by theme:

### New Component Implementation:
* Added `Triptique` component in `front/app/components/Triptique.tsx` to display a section with customizable title, highlight, and cards. Each card includes a title, optional subtitle, and description.
* Defined `TriptiqueProps` and `TriptiqueCard` types in `front/app/types/types.ts` to structure the props for the `Triptique` component.

### Integration into `Home` Route:
* Imported the `Triptique` component in `front/app/routes/home.tsx`.
* Added `triptiqueData` containing statistics and integrated the `Triptique` component into the `Home` route with appropriate props. [[1]](diffhunk://#diff-2e2c068bd027f1427b075b55ee28a2b44ee301154b2e2c941c2c1a4bfea264a2R14-R34) [[2]](diffhunk://#diff-2e2c068bd027f1427b075b55ee28a2b44ee301154b2e2c941c2c1a4bfea264a2R52-R62)

### Styling Enhancement:
* Added `padding: 0.5rem;` to the global CSS file (`front/app/app.css`) for improved spacing.