### PR TITLE
feat: add triptique don section

### DIFF
--- a/front/app/components/Triptique.tsx
+++ b/front/app/components/Triptique.tsx
@@ -8,7 +8,9 @@ export default function Triptique({
   cardBackgroundColor = "bg-beige",
   titleColor = "text-dark",
   cardTitleSize,
+  cardSubtitleeSize = "title4",
   cardTitleColor = "text-dark",
+  cardSubtitleColor = "text-dark",
   cardTextColor = "text-dark",
 }: TriptiqueProps) {
   return (
@@ -32,7 +34,9 @@ export default function Triptique({
                 </h2>
 
                 {card.subtitle && (
-                  <h3 className={`title4 ${cardTitleColor} mb-6`}>
+                  <h3
+                    className={`${cardSubtitleeSize} ${cardSubtitleColor} mb-6`}
+                  >
                     {card.subtitle}
                   </h3>
                 )}

--- a/front/app/routes/home.tsx
+++ b/front/app/routes/home.tsx
@@ -2,6 +2,7 @@ import type { MetaArgs } from "react-router";
 import headerDog from "~/../public/assets/graphic-assets/header-dog.png";
 import Banner from "../components/Banner";
 import Triptique from "../components/Triptique";
+import Button from "~/components/Button";
 
 export function meta({}: MetaArgs) {
   return [
@@ -11,7 +12,7 @@ export function meta({}: MetaArgs) {
 }
 
 export default function Home() {
-  const triptiqueData: [
+  const statistiquesData: [
     { title: string; description: string },
     { title: string; description: string },
     { title: string; description: string },
@@ -29,6 +30,31 @@ export default function Home() {
       title: "= 1465",
       description:
         "En Gironde, la SPA de Bordeaux et du Sud-Ouest a accueilli 1 465 animaux abandonnés en 2022, un chiffre en constante augmentation.",
+    },
+  ];
+
+  const faireUnDonData: [
+    { title: string; subtitle?: string; description: string },
+    { title: string; subtitle?: string; description: string },
+    { title: string; subtitle?: string; description: string },
+  ] = [
+    {
+      title: "01",
+      subtitle: "Choisissez le type de don",
+      description:
+        "Ponctuel ou mensuel, petit ou grand, chaque don a un impact. Vous pouvez nous soutenir une fois, ou rejoindre notre cercle de donateurs réguliers pour accompagner le refuge dans la durée. Quel que soit votre choix, vous contribuez directement à offrir une seconde chance à nos chiens.",
+    },
+    {
+      title: "02",
+      subtitle: "Remplissez le formulaire",
+      description:
+        "En quelques clics, vous indiquez le montant, vos coordonnées et votre préférence de paiement. sNotre formulaire est entièrement sécurisé, et vous avez même la possibilité de dédier votre don à un chien en particulier ou à une action précise (sauvetage, soins, alimentation). sC’est simple, rapide, et totalement transparent.",
+    },
+    {
+      title: "03",
+      subtitle: "Valider et recevez votre reçu",
+      description:
+        "Une fois le paiement validé, vous recevez automatiquement un e-mail de confirmation avec votre reçu fiscal (si applicable). Mais surtout, vous faites désormais partie de celles et ceux qui rendent ce projet possible.",
     },
   ];
 
@@ -52,7 +78,7 @@ export default function Home() {
       <Triptique
         title="Quelques"
         highlight="statistiques clés"
-        cards={triptiqueData}
+        cards={statistiquesData}
         backgroundColor="bg-beige"
         cardBackgroundColor="bg-blue"
         titleColor="text-dark"
@@ -60,6 +86,27 @@ export default function Home() {
         cardTitleColor="text-white-custom"
         cardTextColor="text-beige"
       />
+      <div className="flex flex-col items-center justify-center gap-8 p-4">
+        <Triptique
+          title="Faire un don pour"
+          highlight="sauver une vie"
+          cards={faireUnDonData}
+          backgroundColor=""
+          cardBackgroundColor="bg-beige"
+          titleColor="text-dark"
+          cardTitleSize="title2"
+          cardSubtitleeSize="title5"
+          cardTitleColor="text-red"
+          cardSubtitleColor="text-dark"
+          cardTextColor="text-dark"
+        />
+        <Button
+          className="bg-blue whitespace-nowrap w-fit! px-6 text-white"
+          link=""
+        >
+          Faire un don
+        </Button>
+      </div>
     </main>
   );
 }

--- a/front/app/types/types.ts
+++ b/front/app/types/types.ts
@@ -70,6 +70,8 @@ export type TriptiqueProps = {
   titleColor?: string;
   textColor?: string;
   cardTitleSize?: string;
+  cardSubtitleeSize?: string;
   cardTitleColor?: string;
+  cardSubtitleColor?: string;
   cardTextColor?: string;
 };


### PR DESCRIPTION
This pull request introduces updates to the `Triptique` component and the `Home` route to enhance flexibility and functionality. Key changes include adding new props to `Triptique` for subtitle styling, implementing a new section in the `Home` route for donation information, and updating type definitions accordingly.

### Updates to `Triptique` component:

* Added new props `cardSubtitleeSize` and `cardSubtitleColor` to allow customization of subtitle size and color. [[1]](diffhunk://#diff-a2eaa01c57778375fb9ff946dbbda872d48435966f90ea849a52cf1d00509a45R11-R13) [[2]](diffhunk://#diff-d953b1b2b02da8e6fb366fe7db19f491d2028ccd060dc78bebab977f0fe7e482R73-R75)
* Updated subtitle rendering logic to use the new props for dynamic styling.

### Enhancements to `Home` route:

* Renamed `triptiqueData` to `statistiquesData` for clarity and added a new dataset `faireUnDonData` for donation-related information. [[1]](diffhunk://#diff-2e2c068bd027f1427b075b55ee28a2b44ee301154b2e2c941c2c1a4bfea264a2L14-R15) [[2]](diffhunk://#diff-2e2c068bd027f1427b075b55ee28a2b44ee301154b2e2c941c2c1a4bfea264a2R36-R60)
* Introduced a new section in the `Home` route, featuring the `Triptique` component for donation steps and a `Button` component for donation actions.

### Type definition updates:

* Updated `TriptiqueProps` type to include the new subtitle-related props (`cardSubtitleeSize` and `cardSubtitleColor`).